### PR TITLE
added BusKill 10% off laptop kill cords

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,5 +480,6 @@ Don't forget to:
 | 🤑 | [The Independence Bundle](https://tom-hirst.gumroad.com/l/HKlpmD/BF2022) | All my products. One bundle. One price. Includes every additional premium resource | $73.50 (usually $147) with BF2022
 | 🤑 | [NordVPN](https://nordvpn.com/) | Online VPN service that encrypts your internet traffic and hides your IP with physical location. Upgrade your privacy and security now. | **68% OFF + 3 months free**
 |  💰 | [Remote Leaf](https://remoteleaf.com) | Remote Leaf is the personized remote job board for tech professionals. We hand-pick remote jobs from 100+ sources and send you the jobs that fits for you based on your skills and location. | 50% OFF, on Lifetime Plan - Use code: BLACKFRIDAY |
+|  💵 | [BusKill](https://buskill.in) | BusKill is an open-source hardware and software project that designs computer kill cords to protect the confidentiality of the system's data from physical theft | 10% OFF all orders paid with cryptocurrencies |
 
 [⬆️ Go to Top](#table-of-contents)


### PR DESCRIPTION
Please add the 10% off Black Friday deal for BusKill

## BusKill is 10% off

#### The Deal

BusKill's black friday deal is 10% off all products purchased between Nov 19 to Dec 04 2022.

No code is needed. The total will be reduced by 10% at checkout for all orders paid with cryptocurrencies.

 * https://www.buskill.in/bitcoin-black-friday-2022/

#### What is BusKill?

BusKill is an open-source hardware and software project that uses a hardware tripwire/dead-man-switch (a usb cable with a magnetic breakaway) to trigger your computer to lock or shutdown if the user is physically separated from their machine.

 * https://en.wikipedia.org/wiki/BusKill

The following guide describes how BusKill can be configured to wipe the LUKS Header (containing the FDE key) and its metadata. It shows a video demo where the machine wiped the keys & powered-off in <6 seconds, and it includes a post-execution forensic analysis in Kali with bulk_extractor

 * https://www.buskill.in/luks-self-destruct/