### PR TITLE
fix: weathergraph link

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ Don't forget to:
 |  💵 | [BusKill](https://buskill.in) | BusKill is an open-source hardware and software project that designs computer kill cords to protect the confidentiality of the system's data from physical theft | 10% OFF all orders paid with cryptocurrencies |
 | 🤑 | [McClockface](https://apps.apple.com/app/mcclockface/id1544343485) | Beautiful clock widgets for iOS and iPadOS. | 60% off regular price, one-time lifetime purchase. |
 | 🤑 | [FilmNoir: Movie & TV Show Tracker](https://apps.apple.com/app/apple-store/id1528417240?pt=122011495&ct=blackfriday2022&mt=8) | Discover films and TV shows. Track your full watched history. Find out where to watch. | 50% off the one-time lifetime purchase. Up to 40% off the first year with the code **[BLACKFRIDAY2022](https://apps.apple.com/redeem?ctx=offercodes&id=1528417240&code=BLACKFRIDAY2022)** |
-| 💰 | [Weathergraph weather widget]([https://apps.apple.com/app/mcclockface/id1544343485](https://apps.apple.com/app/apple-store/id1501958576?pt=1920589) | Visual hour-by-hour weather forecast app with widgets and watch complications, made for and by outdoor people. | 30% off for a first year. |
+| 💰 | [Weathergraph weather widget](https://apps.apple.com/app/apple-store/id1501958576?pt=1920589) | Visual hour-by-hour weather forecast app with widgets and watch complications, made for and by outdoor people. | 30% off for a first year. |
 
 
 [⬆️ Go to Top](#table-of-contents)


### PR DESCRIPTION
Fix Weathergraph weather widget link which included `[https://apps.apple.com/app/mcclockface/id1544343485]`, seems to be copied from McClockface. 