### PR TITLE
Adding fullPage.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Don't forget to:
 |  🤑 | [ShellHistory](https://apps.apple.com/us/app/shellhistory/id1564015476) | Keeps zsh, bash, fish history in SQLite with Full Text Search and sync via iCloud | 50% off on App Store. Ends Nov. 29th |
 |  🤑 | [RegExp](https://apps.apple.com/us/app/regexp/id1546140065?mt=12) | Regular Expressions editor (Go, Swift, JavaScript flavours) | Pro is 67% off |
 | 💰 | [FFmpeg.guide](https://ffmpeg.guide) | FFmpeg.guide is a GUI for creating FFmpeg filters and complex commands | 20% OFF with **BLACKFRIDAY20** ends Nov. 29th |
+| 🤑 | [fullPage.js](https://alvarotrigo.com/fullPage/black-friday) | Create beatiful scrolling landing pages with fullPage.js  | Up to 40% OFF with the code **blackf**. Ends Dec 2nd |
 
 
 [⬆️ Go to Top](#table-of-contents)


### PR DESCRIPTION
I've added a link to fullPage.js black Friday offers.

I added it to Developer tools as the main component is a JS library, although we also provide plugins for WordPress. 