### PR TITLE
add golang courses section to table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Don't forget to:
 		- [Mobile/Desktop/Multi-Platform-Apps Courses (4)](#mobiledesktopmulti-platform-apps-courses)
 		- [Data Structure & Algorithm Courses (2)](#data-structure--algorithm-courses)
 		- [C#/.Net Courses (4)](#cnet-courses)
-   		- [Go (Golang) Courses (4)](#go-golang-courses)
+   		- [Go (Golang) Courses (1)](#go-golang-courses)
 		- [InfoSec Courses (1)](#infosec-courses)
 		- [Programming Courses From Platforms (10)](#programming-courses-from-platforms)
 		- [Other General Programming Courses (9)](#other-general-programming-courses)

--- a/README.md
+++ b/README.md
@@ -268,11 +268,15 @@ Don't forget to:
 | -- | ---| ------ | ------ |
 |  👑 | Your Spot | [Submit your discount](https://github.com/trungdq88/Awesome-Black-Friday-Cyber-Monday/issues/368) now to secure the top spot! | 💸 |
 
+
+[⬆️ Go to Top](#table-of-contents)
+
 #### Go (Golang) Courses
 
 |  | Name | Description | Discount Code & Terms |
 | -- | ---| ------ | ------ |
 |  🤑 | [Learn Programming with Go (Golang), One Game at a Time](https://www.udemy.com/course/learn-programming-with-go/?couponCode=BLACKFRIDAY) | Learn Programming using the Go (Golang) programming language by building your own games. Excellent for beginners, who are starting out w/ programming or want to pick up Golang. | 80% OFF with code **BLACKFRIDAY** |
+
 
 [⬆️ Go to Top](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Don't forget to:
 		- [Mobile/Desktop/Multi-Platform-Apps Courses (4)](#mobiledesktopmulti-platform-apps-courses)
 		- [Data Structure & Algorithm Courses (2)](#data-structure--algorithm-courses)
 		- [C#/.Net Courses (4)](#cnet-courses)
+   		- [Go (Golang) Courses (4)](#go-golang-courses)
 		- [InfoSec Courses (1)](#infosec-courses)
 		- [Programming Courses From Platforms (10)](#programming-courses-from-platforms)
 		- [Other General Programming Courses (9)](#other-general-programming-courses)


### PR DESCRIPTION
also added missing "Go to Top" marker on the .net courses section as I accidentally removed it.