### PR TITLE
Adding VPS2day

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,6 +799,6 @@ Total deals: 453
 | 🤑 | [Eter](https://apps.apple.com/app/eter/id1523221566) | Internet Radio player (iOS, Mac, TV, Watch) | 50% off (only US$2.5) |
 | 💰 | [Indie Masterminds](https://indiemasterminds.com/?ref=black_friday_deals_by_tony) | Tight knit community of indie founders. Private slack with 90+ members, premium courses, sprints and more. | 20% off on lifetime or annual plan with the code **`BFCM23`** | Valid till 27th Nov, 2023 |
 | 💰 | [BoringCashCow](https://boringcashcow.com/?ref=black_friday_deals_by_tony) | Discover Boring Businesses that Quietly Rake in the Cash Home. | 30% off with code **`godalRdf`** | Valid till 27th Nov, 2023 |
-
+| 🤑 | [VPS2day](https://www.vps2day.com/pricing?mtm_campaign=black-friday-2023&mtm_source=github&mtm_cid=trungdq88-awesome-black-friday-cyber-monday) | 100% prepaid virtual private servers (VPS) with unrestricted root access for [self-hosted software](https://github.com/awesome-selfhosted/awesome-selfhosted), VPNs, bots, crawlers, etc. | Up to 73% discount on special VPS types (Valid till 27th Nov, 2023) |
 
 [⬆️ Go to Top](#table-of-contents)


### PR DESCRIPTION
VPS2day is a prepaid virtual server (VPS) hosting provider. We have three special VPS type offerings, starting tomorrow 24th Nov, 2023, valid through 27 Nov, 2023.

This offer should fit the miscellaneous pretty good. It's a nice possibility to get some cheap server resources to e.g. try out some self-hosted open source software to be found on GitHub or to host a dedicated and personal VPN service with a one-click VPN installer.