### PR TITLE
Add Budget Zen's Black Friday 2024 Deal

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Total deals: 0
 |  | Name | Description | Discount Code & Terms |
 | -- | ---| ------ | ------ |
 |  ⭐ | [(Example entry)](https://devutils.com) | All-in-one toolbox for developers. Fully supports Apple Silicon & macOS Ventura. | 50% OFF with code **BLACKFRIDAY_2024** |
+|  💵 | [(Budget Zen)](https://budgetzen.net) | Simple and End-to-End Encrypted Budget & Expenses Manager. | 50% OFF on the annual subscription with code **FRIDAY24** |
 
 
 [⬆️ Go to Top](#table-of-contents)


### PR DESCRIPTION
Budget Zen is present in https://github.com/pluja/awesome-privacy?tab=readme-ov-file#fiat and https://awesome-selfhosted.net/tags/money-budgeting--management.html#budget-zen too (it's also open source software and self-hostable, but the deal doesn't make sense in _that_ case, only for the cloud offering).