### PR TITLE
Add Remote Jobs Braintrust course Black Friday discount

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ Total deals: 110
 | -- | ---| ------ | ------ |
 |  ⭐ | [Taro](https://www.jointaro.com/membership/) | Expert-led courses to accelerate your career: job searching, interviewing, onboarding, promotion, and more. | 25% OFF with code **THANKS24** |
 |  ⭐ | [From 0 to $1000 on Upwork](https://k2a2.gumroad.com/l/from-0-to-1000-upwork/BLACKFRIDAY) | One hour course to go from 0 to $1000 on Upwork. | 50% OFF with code **BLACKFRIDAY** (Discount added to link |
+|  ⭐ | [Remote Jobs Braintrust](https://sergiorocks.gumroad.com/l/remote-jobs-braintrust) | 14-session course and 200+ member Slack community to help you land your dream remote job. | 60% OFF during November/2024 |
 
 [⬆️ Go to Top](#table-of-contents)
 


### PR DESCRIPTION
Adding Remote Jobs Braintrust course + community to the Black Friday list.