### PR TITLE
Add OVH VPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Total deals: 489
 | 🔨 | [HammerAI](https://www.hammerai.com/?utm_source=bf) | Private and uncensored character chat app - either run models locally with Ollama, or use our cloud-hosted models. | 50% OFF with code **BZAOH18** |
 | ⛰️ | [Heights Platform](https://heightsplatform.com/black-friday-2024?utm_source=awesomebf) | All-in-one platform for creating & selling online courses, digital products, community memberships and coaching programs with Heights AI 2. | 35% OFF, save up to $1000 - no code needed |
 | 🤑 | [AnySelect](https://anyselectai.com/) | The best and quickest way to use ChatGPT/LLM from any app on macOS! | 60% OFF with this discount code **`BF2024`** |
+|  ⭐ | [OVH VPS](https://us.ovh.com/us/order/vps/) | Virtual Private Server Instance (VPS): 1 vCore, 2 GB RAM, 20 GB SSD SATA, public bandwidth 100Mbps | -77% the first 12 months (New customer, 10 max) |
 
 [⬆️ Go to Top](#table-of-contents)
 


### PR DESCRIPTION
Starter
-77% the first 12 months (New customer, 10 max)
Processor 1 vCore
Memory 2 GB
Storage 20 GB SSD SATA
Public bandwidth 100Mbps
$0.97 /month