### PR TITLE
Add link to interactive deals browser website

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Hi there! ❤️ I built multiple profitable products in public and also maintai
 | Your Personal AI Workspace.<br/>BLACKFRIDAY_2024<br/><br/>Frontend for ChatGPT, Claude, Gemini to use with your API key. Support Artifact, Projects, Vision, Canvas, AI agents builder, DALL-E, Plugins, etc. | All-in-one toolbox for developers.<br/>BLACKFRIDAY_2024 <br/><br/> 42+ carefully crafted developer tools. Native macOS app, fast & beautiful. Work offline, and respect your data. Fully supports Apple Silicon & macOS Ventura. | Discount code: BF24<br/><br/>CompressX is a powerful offline media compression tool that can significantly reduce file sizes without compromising quality |
 
 
+You can also browse these deals with filters [here](https://cybermondaydeals2024.com/).
+
 ## Table of Contents
 
 Total deals: 648


### PR DESCRIPTION
After using this awesome deals list ourselves, we found that having a way to filter and search would improve the browsing experience. So we built [cybermondaydeals2024.com](https://cybermondaydeals2024.com/) to help others find deals more easily.

- Added a link to the website which provides a searchable interface to browse the deals list
- The website includes category filters to help users find relevant deals more quickly
- This complements the existing GitHub list by providing an alternative way to explore the deals

The website is built based on the data from this repository and makes it more accessible to users who prefer an interactive browsing experience.