### PR TITLE
Add Reepl - 60% OFF Annual Plan for Black Friday 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ Total deals: 223
 | 🔖 | [TweetsMash](https://www.tweetsmash.com?ref=tonybf)￼ | Import, search, organize, and export all your Twitter/X bookmarks with AI. Notion/Sheets sync with API access, List Digest, and powerful filters. | 30% OFF with code **TONYDEALS2025** |
 | 💼 | [LinkedMash](https://www.linkedmash.com?ref=tonybf)￼ | Turn your LinkedIn saved posts into an organized knowledge system. Import, tag, search, export to Notion/Sheets/Airtable with API access — and unlock AI insights. | 30% OFF with code **TONYDEALS2025** |
 | 🚀 | [Nuelink](https://www.nuelink.com/) | Nuelink is a social media management platform that automates scheduling, publishing, and content workflows across major platforms like Instagram, Twitter/X, LinkedIn, TikTok, and YouTube. It offers powerful features such as bulk scheduling, post recycling, analytics, content automation, integrations with tools like Zapier and n8n, AI-powered caption generation, and team collaboration tools. All designed to simplify content management and scale social media growth efficiently. | **30% off** monthly & Up to **65% off** yearly|
+| 🤖 | [Reepl](https://app.reepl.io/claim-offer/BLACKFRIDAY2025) | Grow your LinkedIn without living on it. Train AI on your writing, automate personalized DMs/comments, schedule posts, track contacts. Built for busy professionals. | **60% OFF** annual plan with code **BLACKFRIDAY2025** |
 
 ⬆️ | [Go to Top](#table-of-contents)
 
@@ -427,6 +428,5 @@ Total deals: 223
 | 📻 | [Macrowave](https://macrowave.co) - Private P2P Radio | Macrowave turns your Mac/iPhone into a private radio station. Share any audio from your Mac with anyone, anywhere. No accounts, no setup, just a link. Perfect for listening to music together or creating your own private live podcast. | One-time ~~$119.99~~ **$79.99**. |
 | 🔐 | [Eternal Vault](https://eternalvault.app) | Secure bridge between your life and your loved ones | **20% OFF** on all plans (incl lifetime) using code **BLACKFRIDAY2025** |
 | 🎙️  | [Podigy Podcast Player](https://apps.apple.com/us/app/podcast-player-podigy/id6473860416) | Best in class podcast player for iPhone, iPad and Mac. Trim silence, boost voices, CarPlay support and more.                                                                                                                              | 30% off on annual plan via the App Store. |
-| 🤖 | [Reepl](https://app.reepl.io/claim-offer/BLACKFRIDAY2025) | Grow your LinkedIn without living on it. Train AI on your writing, automate personalized DMs/comments, schedule posts, track contacts. Built for busy professionals. | **60% OFF** annual plan with code **BLACKFRIDAY2025** |
 
 ⬆️ | [Go to Top](#table-of-contents)


### PR DESCRIPTION
## Deal Submission

**Product:** Reepl  
**URL:** https://app.reepl.io/claim-offer/BLACKFRIDAY2025  
**Category:** Miscellaneous  
**Discount:** 60% OFF annual plan with code BLACKFRIDAY2025

### Product Description
Reepl is an AI-powered LinkedIn automation platform that helps busy professionals grow their LinkedIn presence without spending hours daily. Features include:

- Train AI on your own writing style for authentic engagement
- Automate personalized DMs and comments
- Content scheduler for consistent posting
- Contact management and tracking
- Built for professionals who want LinkedIn results without the time investment

### Deal Details
- **Regular Price:** $180/year
- **Black Friday Price:** $72/year (60% discount)
- **Code:** BLACKFRIDAY2025
- **Valid:** Through December 1st, 2025

### Compliance
✅ Added to end of Miscellaneous section (as per rules)  
✅ Not 100% off or free-while-in-beta  
✅ Clear pricing and discount details  
✅ Direct product link (no shortened URLs)  
✅ Cool, quality, interesting product for LinkedIn professionals  

---

Thank you for considering our submission! 🎉